### PR TITLE
Update TTL timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macrometa-realtime-cache",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache-2.0",
   "description": "The official C8 realtime cache JavaScript driver.",
   "homepage": "https://github.com/macrometacorp/mmcache",

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,7 +39,7 @@ export default class Client extends Connection {
 
   getExpireAtTimeStamp(ttl: number) {
     const currDate = new Date();
-    currDate.setSeconds(ttl);
+    currDate.setSeconds(currDate.getSeconds() + ttl);
 
     return currDate.getTime() / 1000;
   }


### PR DESCRIPTION
`setSeconds` must receive the sum of TTL and current seconds value as parameter.